### PR TITLE
Fix : mauvaise URL pour la section archives du site git-attitude.fr

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@ git rerere clear
           <br>
           <p>Christophe Porteneuve</p>
           <p><a href="https://twitter.com/porteneuve">@porteneuve</a></p>
-          <p><a href="http://www.git-attitude.fr/archives/">Les articles de fond qui vont bien</a></p>
+          <p><a href="http://www.git-attitude.fr/blog/archives/">Les articles de fond qui vont bien</a></p>
           <p><a href="http://www.git-attitude.fr/git-total/">La formation qui tue tout</a></p>
 
           <p class="breathing">


### PR DESCRIPTION
Modification de l'URL du slide pointant vers la section archives du site git-attitude.fr.
